### PR TITLE
Changed segment of while condition in waitForProcessCompletion() 

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1254,7 +1254,7 @@ bool OrganizerCore::waitForProcessCompletion(HANDLE handle, LPDWORD exitCode)
   while (
 	  res = ::MsgWaitForMultipleObjects(1, &handle, false, 500,
 		  QS_KEY | QS_MOUSE),
-		  ((res != WAIT_FAILED) || (res != WAIT_OBJECT_0)) &&
+		  ((res != WAIT_FAILED) && (res != WAIT_OBJECT_0)) &&
 	  ((m_UserInterface == nullptr) || !m_UserInterface->unlockClicked())) {
 
 	  if (!::GetVFSProcessList(&numProcesses, processes)) {


### PR DESCRIPTION
From OR to AND as it alwais evaluated true and thus still entered the cicle even if MsgWaitForMultipleObjects returned WAIT_FAILED or WAIT_OBJECT_0