### PR TITLE
Added !found condition to for loop to avoid possible leak.

### DIFF
--- a/src/organizercore.cpp
+++ b/src/organizercore.cpp
@@ -1264,7 +1264,7 @@ bool OrganizerCore::waitForProcessCompletion(HANDLE handle, LPDWORD exitCode)
 	  size_t count =
 		  std::min<size_t>(static_cast<size_t>(maxCount), numProcesses);
 	  if (count > 0) {
-		  for (size_t i = 0; i < count; ++i) {
+		  for (size_t i = 0; i < count && !found; ++i) {
 			  std::wstring processName = getProcessName(processes[i]);
 			  if (!boost::starts_with(processName, L"ModOrganizer.exe")) {
 				  if (!boost::starts_with(processName, L"unknown")) {


### PR DESCRIPTION
Added !found condition to for loop to ensure that it stops after finding a valid processHandle so that it can't be overwritten to avoid handle leaks. The valid processHandle is then closed by cleanup code inside the while loop. This won't affect the rest of the code as found gets reinitialized to False at the start of the while loop. 