### PR TITLE
Fixed to get rid of WindowsWindow::setGeometry: Unable to set geometry bug.

### DIFF
--- a/src/editexecutablesdialog.ui
+++ b/src/editexecutablesdialog.ui
@@ -10,6 +10,12 @@
     <height>460</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>200</width>
+    <height>200</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Modify Executables</string>
   </property>


### PR DESCRIPTION
Fixed to get rid of WindowsWindow::setGeometry: Unable to set geometry bug.