### PR TITLE
Fix for MO finding the wrong game to manage.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,6 +318,9 @@ MOBase::IPluginGame *determineCurrentGame(QString const &moPath, QSettings &sett
     }
   }
 
+  //The following code would try to determine the right game to mange but it would usually find the wrong one
+  //so it was commented out.
+  /* 
   //OK, we are in a new setup or existing info is useless.
   //See if MO has been installed inside a game directory
   for (IPluginGame * const game : plugins.plugins<IPluginGame>()) {
@@ -341,6 +344,7 @@ MOBase::IPluginGame *determineCurrentGame(QString const &moPath, QSettings &sett
       //OK, chop off the last directory and try again
     } while (gameDir.cdUp());
   }
+  */
 
   //Then try a selection dialogue.
   if (!gamePath.isEmpty() || !gameName.isEmpty()) {


### PR DESCRIPTION
Commented out code that tried to deduce game and found wrong one. Now, if not already set in INI, file MO will ask the user which one to manage.