### PR TITLE
Fixed handling of nexus links for FO4VR.

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -451,7 +451,7 @@ void DownloadManager::addNXMDownload(const QString &url)
 {
   NXMUrl nxmInfo(url);
 
-  QString managedGame = m_ManagedGame->gameShortName();
+  QString managedGame = m_ManagedGame->gameNexusName();
   qDebug("add nxm download: %s", qPrintable(url));
   if (nxmInfo.game().compare(managedGame, Qt::CaseInsensitive) != 0) {
     qDebug("download requested for wrong game (game: %s, url: %s)", qPrintable(managedGame), qPrintable(nxmInfo.game()));
@@ -1246,7 +1246,7 @@ int DownloadManager::startDownloadURLs(const QStringList &urls)
 int DownloadManager::startDownloadNexusFile(int modID, int fileID)
 {
   int newID = m_ActiveDownloads.size();
-  addNXMDownload(QString("nxm://%1/mods/%2/files/%3").arg(m_ManagedGame->gameShortName()).arg(modID).arg(fileID));
+  addNXMDownload(QString("nxm://%1/mods/%2/files/%3").arg(m_ManagedGame->gameNexusName()).arg(modID).arg(fileID));
   return newID;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -133,7 +133,7 @@ void Settings::registerAsNXMHandler(bool force)
   std::wstring nxmPath = ToWString(QCoreApplication::applicationDirPath() + "/nxmhandler.exe");
   std::wstring executable = ToWString(QCoreApplication::applicationFilePath());
   std::wstring mode = force ? L"forcereg" : L"reg";
-  std::wstring parameters = mode + L" " + m_GamePlugin->gameShortName().toStdWString() + L" \"" + executable + L"\"";
+  std::wstring parameters = mode + L" " + m_GamePlugin->gameNexusName().toStdWString() + L" \"" + executable + L"\"";
   HINSTANCE res = ::ShellExecuteW(nullptr, L"open", nxmPath.c_str(), parameters.c_str(), nullptr, SW_SHOWNORMAL);
   if ((int)res <= 32) {
     QMessageBox::critical(nullptr, tr("Failed"),


### PR DESCRIPTION
When managing a Fallout 4 VR installation MO was unable to handle nexus links. The reason was that for checking the validity of a nxm download and for registering at the link handler gameShortName() was used instead of gameNexusName().