### PR TITLE
set MO as StartUp Project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 PROJECT(organizer)
 
+# sets ModOrganizer as StartUp Project in Visual Studio
+set_property(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" PROPERTY VS_STARTUP_PROJECT "${CMAKE_PROJECT_NAME}")
 
 SET(DEPENDENCIES_DIR CACHE PATH "")
 # hint to find qt in dependencies path


### PR DESCRIPTION
Sets MordOrganizer as StartUp Project in VisualStudio.
Reference: https://stackoverflow.com/a/37994396/4446318